### PR TITLE
Fix build failure by disabling gralloc related sources

### DIFF
--- a/gfx/gl/moz.build
+++ b/gfx/gl/moz.build
@@ -156,11 +156,5 @@ CFLAGS += CONFIG['TK_CFLAGS']
 
 LOCAL_INCLUDES += CONFIG['SKIA_INCLUDES']
 
-if CONFIG['MOZ_WIDGET_TOOLKIT'] == 'gonk':
-    UNIFIED_SOURCES += ['SharedSurfaceGralloc.cpp']
-    EXPORTS += ['SharedSurfaceGralloc.h']
-    LOCAL_INCLUDES += ['/widget/gonk']
-    LOCAL_INCLUDES += ['%' + '%s/%s' % (CONFIG['GONK_PATH'], 'hardware/libhardware/include')]
-
 if CONFIG['CC_TYPE'] in ('clang', 'gcc'):
     CXXFLAGS += ['-Wno-error=shadow']

--- a/gfx/layers/ipc/LayersSurfaces.ipdlh
+++ b/gfx/layers/ipc/LayersSurfaces.ipdlh
@@ -4,8 +4,6 @@
 
 using struct gfxPoint from "gfxPoint.h";
 using nsIntRegion from "nsRegion.h";
-using struct mozilla::layers::MagicGrallocBufferHandle from "gfxipc/ShadowLayerUtils.h";
-using struct mozilla::layers::GrallocBufferRef from "gfxipc/ShadowLayerUtils.h";
 using struct mozilla::layers::SurfaceDescriptorX11 from "gfxipc/ShadowLayerUtils.h";
 using mozilla::StereoMode from "ImageTypes.h";
 using mozilla::YUVColorSpace from "ImageTypes.h";
@@ -17,14 +15,12 @@ using mozilla::gfx::IntRect from "mozilla/gfx/Rect.h";
 using mozilla::gfx::IntSize from "mozilla/gfx/Point.h";
 using mozilla::ipc::SharedMemoryBasic::Handle from "mozilla/ipc/SharedMemoryBasic.h";
 using gfxImageFormat from "gfxTypes.h";
-using struct mozilla::layers::GonkNativeHandle from "mozilla/layers/GonkNativeHandleUtils.h";
 
 namespace mozilla {
 namespace layers {
 
 union OverlayHandle {
   int32_t;
-  GonkNativeHandle;
   null_t;
 };
 
@@ -34,8 +30,6 @@ struct OverlaySource {
 };
 
 union MaybeMagicGrallocBufferHandle {
-  MagicGrallocBufferHandle;
-  GrallocBufferRef;
   null_t;
 };
 

--- a/gfx/layers/ipc/ShadowLayerUtils.h
+++ b/gfx/layers/ipc/ShadowLayerUtils.h
@@ -28,21 +28,6 @@ struct SurfaceDescriptorX11 {
 }  // namespace mozilla
 #endif
 
-#if defined(MOZ_WIDGET_GONK)
-# include "mozilla/layers/ShadowLayerUtilsGralloc.h"
-#else
-namespace mozilla { namespace layers {
-struct MagicGrallocBufferHandle {
-  bool operator==(const MagicGrallocBufferHandle&) const { return false; }
-};
-
-struct GrallocBufferRef {
-  bool operator==(const GrallocBufferRef&) const { return false; }
-};
-} // namespace layers
-} // namespace mozilla
-#endif
-
 namespace IPC {
 
 #if !defined(MOZ_HAVE_SURFACEDESCRIPTORX11)
@@ -55,22 +40,6 @@ struct ParamTraits<mozilla::layers::SurfaceDescriptorX11> {
   }
 };
 #endif  // !defined(MOZ_HAVE_XSURFACEDESCRIPTORX11)
-
-#if !defined(MOZ_HAVE_SURFACEDESCRIPTORGRALLOC)
-template <>
-struct ParamTraits<mozilla::layers::MagicGrallocBufferHandle> {
-  typedef mozilla::layers::MagicGrallocBufferHandle paramType;
-  static void Write(Message*, const paramType&) {}
-  static bool Read(const Message*, void**, paramType*) { return false; }
-};
-
-template <>
-struct ParamTraits<mozilla::layers::GrallocBufferRef> {
-  typedef mozilla::layers::GrallocBufferRef paramType;
-  static void Write(Message*, const paramType&) {}
-  static bool Read(const Message*, void**, paramType*) { return false; }
-};
-#endif  // !defined(MOZ_HAVE_XSURFACEDESCRIPTORGRALLOC)
 
 template <>
 struct ParamTraits<mozilla::ScreenRotation>

--- a/gfx/layers/ipc/ShadowLayers.cpp
+++ b/gfx/layers/ipc/ShadowLayers.cpp
@@ -30,7 +30,6 @@
 #include "mozilla/layers/LayersSurfaces.h"  // for SurfaceDescriptor, etc
 #include "mozilla/layers/LayersTypes.h"     // for MOZ_LAYERS_LOG
 #include "mozilla/layers/LayerTransactionChild.h"
-#include "mozilla/layers/SharedBufferManagerChild.h"
 #include "mozilla/layers/PTextureChild.h"
 #include "mozilla/layers/SyncObject.h"
 #ifdef XP_DARWIN

--- a/gfx/layers/moz.build
+++ b/gfx/layers/moz.build
@@ -28,7 +28,6 @@ EXPORTS += [
     'FrameMetrics.h',
     'GLImages.h',
     'GPUVideoImage.h',
-    'GrallocImages.h',
     'ImageContainer.h',
     'ImageLayers.h',
     'ImageTypes.h',
@@ -185,9 +184,6 @@ EXPORTS.mozilla.layers += [
     'ipc/CompositorVsyncScheduler.h',
     'ipc/CompositorVsyncSchedulerOwner.h',
     'ipc/ContentCompositorBridgeParent.h',
-    'ipc/FenceUtils.h',
-    'ipc/GonkNativeHandle.h',
-    'ipc/GonkNativeHandleUtils.h',
     'ipc/ImageBridgeChild.h',
     'ipc/ImageBridgeParent.h',
     'ipc/ISurfaceAllocator.h',
@@ -200,8 +196,6 @@ EXPORTS.mozilla.layers += [
     'ipc/RefCountedShmem.h',
     'ipc/RemoteContentController.h',
     'ipc/ShadowLayers.h',
-    'ipc/SharedBufferManagerChild.h',
-    'ipc/SharedBufferManagerParent.h',
     'ipc/SharedPlanarYCbCrImage.h',
     'ipc/SharedRGBImage.h',
     'ipc/SharedSurfacesChild.h',
@@ -229,8 +223,6 @@ EXPORTS.mozilla.layers += [
     'mlgpu/UtilityMLGPU.h',
     'opengl/CompositingRenderTargetOGL.h',
     'opengl/CompositorOGL.h',
-    'opengl/GrallocTextureClient.h',
-    'opengl/GrallocTextureHost.h',
     'opengl/MacIOSurfaceTextureClientOGL.h',
     'opengl/MacIOSurfaceTextureHostOGL.h',
     'opengl/TextureClientOGL.h',
@@ -317,34 +309,6 @@ if CONFIG['MOZ_WIDGET_TOOLKIT'] == 'android':
     ]
     EXPORTS.mozilla.layers += [
         'apz/src/AndroidDynamicToolbarAnimator.h',
-    ]
-
-# NB: Gralloc is available on other platforms that use the android GL
-# libraries, but only Gonk is able to use it reliably because Gecko
-# has full system permissions there.
-if CONFIG['MOZ_WIDGET_TOOLKIT'] == 'gonk':
-    EXPORTS.mozilla.layers += [
-        'basic/GrallocTextureHostBasic.h',
-        'ipc/ShadowLayerUtilsGralloc.h',
-    ]
-    UNIFIED_SOURCES += [
-        'basic/GrallocTextureHostBasic.cpp',
-        'GrallocImages.cpp',
-        'opengl/EGLImageHelpers.cpp',
-        'opengl/GrallocTextureClient.cpp',
-        'opengl/GrallocTextureHost.cpp',
-    ]
-    LOCAL_INCLUDES += ['/widget/gonk']
-    if CONFIG['ANDROID_VERSION'] >= '21':
-        LOCAL_INCLUDES += [
-             '%' + '%s/%s' % (CONFIG['GONK_PATH'], d) for d in [
-                 'system/core/libsync/include'
-             ]
-        ]
-    SOURCES += [
-        'ipc/GonkNativeHandle.cpp',
-        'ipc/GonkNativeHandleUtils.cpp',
-        'ipc/ShadowLayerUtilsGralloc.cpp',
     ]
 
 UNIFIED_SOURCES += [
@@ -463,7 +427,6 @@ UNIFIED_SOURCES += [
     'ipc/CompositorThread.cpp',
     'ipc/CompositorVsyncScheduler.cpp',
     'ipc/ContentCompositorBridgeParent.cpp',
-    'ipc/FenceUtils.cpp',
     'ipc/ImageBridgeChild.cpp',
     'ipc/ImageBridgeParent.cpp',
     'ipc/ISurfaceAllocator.cpp',
@@ -474,8 +437,6 @@ UNIFIED_SOURCES += [
     'ipc/RefCountedShmem.cpp',
     'ipc/RemoteContentController.cpp',
     'ipc/ShadowLayers.cpp',
-    'ipc/SharedBufferManagerChild.cpp',
-    'ipc/SharedBufferManagerParent.cpp',
     'ipc/SharedPlanarYCbCrImage.cpp',
     'ipc/SharedRGBImage.cpp',
     'ipc/SharedSurfacesChild.cpp',
@@ -575,7 +536,6 @@ IPDL_SOURCES += [
     'ipc/PCompositorManager.ipdl',
     'ipc/PImageBridge.ipdl',
     'ipc/PLayerTransaction.ipdl',
-    'ipc/PSharedBufferManager.ipdl',
     'ipc/PTexture.ipdl',
     'ipc/PUiCompositorController.ipdl',
     'ipc/PVideoBridge.ipdl',
@@ -612,22 +572,6 @@ if CONFIG['MOZ_DEBUG']:
 
 if CONFIG['MOZ_ENABLE_D3D10_LAYER']:
     DEFINES['MOZ_ENABLE_D3D10_LAYER'] = True
-
-if CONFIG['MOZ_WIDGET_TOOLKIT'] == 'gonk':
-    if CONFIG['ANDROID_VERSION'] >= '17':
-        includes = [
-            'frameworks/av/include/media/stagefright',
-            'frameworks/native/include/media/openmax',
-        ]
-    else:
-        includes = [
-            'frameworks/base/include/media/stagefright',
-            'frameworks/base/include/media/stagefright/openmax',
-        ]
-
-    LOCAL_INCLUDES += [
-        '%' + '%s/%s' % (CONFIG['GONK_PATH'], d) for d in includes
-    ]
 
 if CONFIG['ENABLE_TESTS']:
     DIRS += ['apz/test/gtest']

--- a/gfx/thebes/gfxPlatform.cpp
+++ b/gfx/thebes/gfxPlatform.cpp
@@ -103,10 +103,6 @@
 #include "GLContextProvider.h"
 #include "mozilla/gfx/Logging.h"
 
-#ifdef MOZ_WIDGET_GONK
-#include "mozilla/layers/GrallocTextureHost.h"
-#endif
-
 #ifdef USE_SKIA
 #  ifdef __GNUC__
 #    pragma GCC diagnostic push
@@ -146,9 +142,6 @@ static const uint32_t kDefaultGlyphCacheSize = -1;
 
 namespace mozilla {
 namespace layers {
-#ifdef MOZ_WIDGET_GONK
-void InitGralloc();
-#endif
 void ShutdownTileCache();
 } // namespace layers
 } // namespace mozilla
@@ -1025,10 +1018,6 @@ void gfxPlatform::Init() {
 
   GLContext::PlatformStartup();
 
-#ifdef MOZ_WIDGET_GONK
-    mozilla::layers::InitGralloc();
-#endif
-
   Preferences::RegisterCallbackAndCall(RecordingPrefChanged,
                                        "gfx.2d.recording");
 
@@ -1271,9 +1260,6 @@ void gfxPlatform::InitLayersIPC() {
     }
 
     layers::CompositorThreadHolder::Start();
-#ifdef MOZ_WIDGET_GONK
-    SharedBufferManagerChild::StartUp();
-#endif
   }
 }
 
@@ -1299,9 +1285,6 @@ void gfxPlatform::ShutdownLayersIPC() {
     gfx::VRManagerChild::ShutDown();
     layers::CompositorManagerChild::Shutdown();
     layers::ImageBridgeChild::ShutDown();
-#ifdef MOZ_WIDGET_GONK
-    layers::SharedBufferManagerChild::ShutDown();
-#endif
 
     // This has to happen after shutting down the child protocols.
     layers::CompositorThreadHolder::Shutdown();
@@ -1561,17 +1544,17 @@ void gfxPlatform::ComputeTileSize() {
       w = h = clamped(int32_t(RoundUpPow2(screenSize.width)) / 4, 256, 1024);
     }
 
-#ifdef MOZ_WIDGET_GONK
-    android::sp<android::GraphicBuffer> alloc =
-          new android::GraphicBuffer(w, h, android::PIXEL_FORMAT_RGBA_8888,
-                                     android::GraphicBuffer::USAGE_SW_READ_OFTEN |
-                                     android::GraphicBuffer::USAGE_SW_WRITE_OFTEN |
-                                     android::GraphicBuffer::USAGE_HW_TEXTURE);
-
-    if (alloc.get()) {
-      w = alloc->getStride(); // We want the tiles to be gralloc stride aligned.
-    }
-#endif
+//#ifdef MOZ_WIDGET_GONK
+//    android::sp<android::GraphicBuffer> alloc =
+//          new android::GraphicBuffer(w, h, android::PIXEL_FORMAT_RGBA_8888,
+//                                     android::GraphicBuffer::USAGE_SW_READ_OFTEN |
+//                                     android::GraphicBuffer::USAGE_SW_WRITE_OFTEN |
+//                                     android::GraphicBuffer::USAGE_HW_TEXTURE);
+//
+//    if (alloc.get()) {
+//      w = alloc->getStride(); // We want the tiles to be gralloc stride aligned.
+//    }
+//#endif
   }
 
   // Don't allow changing the tile size after we've set it.

--- a/xpcom/build/XPCOMInit.cpp
+++ b/xpcom/build/XPCOMInit.cpp
@@ -26,7 +26,6 @@
 
 #include "mozilla/layers/ImageBridgeChild.h"
 #include "mozilla/layers/CompositorBridgeParent.h"
-#include "mozilla/layers/SharedBufferManagerChild.h"
 
 #include "prlink.h"
 


### PR DESCRIPTION
We could put off gralloc TextureClient usage. Then the change just disable to build the related code to address build failure.