### PR TITLE
Disable cairo usage for content

### DIFF
--- a/b2g/app/b2g.js
+++ b/b2g/app/b2g.js
@@ -339,7 +339,6 @@ pref("dom.ipc.tabs.disabled", true);
 pref("dom.ipc.tabs.disabled", false);
 pref("layers.acceleration.disabled", false);
 pref("layers.async-pan-zoom.enabled", true);
-pref("gfx.content.azure.backends", "cairo");
 #endif
 
 // Web Notifications


### PR DESCRIPTION
Remove cairo usage for content. Latest m-c uses skia as default backend. The change addresses a warning in TextureClient::CreateForDrawing().