### PR TITLE
Add basic support of gralloc

### DIFF
--- a/dom/ipc/ContentChild.cpp
+++ b/dom/ipc/ContentChild.cpp
@@ -106,6 +106,10 @@
 #  include "mozilla/Omnijar.h"
 #endif
 
+#ifdef MOZ_WIDGET_GONK
+#include "mozilla/layers/SharedBufferManagerChild.h"
+#endif
+
 #ifdef MOZ_GECKO_PROFILER
 #  include "ChildProfilerController.h"
 #endif
@@ -1379,6 +1383,26 @@ mozilla::ipc::IPCResult ContentChild::RecvRequestPerformanceMetrics(
                     and proceeds when the data is not coming back */
           });
 
+  return IPC_OK();
+}
+
+mozilla::ipc::IPCResult ContentChild::RecvInitBufferManager(
+      Endpoint<PSharedBufferManagerChild> aBufferManager) {
+#ifdef MOZ_WIDGET_GONK
+  if (!SharedBufferManagerChild::InitForContent(std::move(aBufferManager))) {
+    return IPC_FAIL(this, "SharedBufferManagerChild::InitForContent failed!");
+  }
+#endif
+  return IPC_OK();
+}
+
+mozilla::ipc::IPCResult ContentChild::RecvReinitBufferManager(
+      Endpoint<PSharedBufferManagerChild> aBufferManager) {
+#ifdef MOZ_WIDGET_GONK
+  if (!SharedBufferManagerChild::ReinitForContent(std::move(aBufferManager))) {
+    return IPC_FAIL(this, "SharedBufferManagerChild::ReinitForContent failed!");
+  }
+#endif
   return IPC_OK();
 }
 

--- a/dom/ipc/ContentChild.h
+++ b/dom/ipc/ContentChild.h
@@ -170,6 +170,12 @@ class ContentChild final : public PContentChild,
   mozilla::ipc::IPCResult RecvInitProcessHangMonitor(
       Endpoint<PProcessHangMonitorChild>&& aHangMonitor);
 
+  mozilla::ipc::IPCResult RecvInitBufferManager(
+      Endpoint<PSharedBufferManagerChild> aBufferManager);
+
+  mozilla::ipc::IPCResult RecvReinitBufferManager(
+      Endpoint<PSharedBufferManagerChild> aBufferManager);
+
   mozilla::ipc::IPCResult RecvInitRendering(
       Endpoint<PCompositorManagerChild>&& aCompositor,
       Endpoint<PImageBridgeChild>&& aImageBridge,

--- a/dom/ipc/ContentParent.cpp
+++ b/dom/ipc/ContentParent.cpp
@@ -2514,8 +2514,15 @@ void ContentParent::InitInternal(ProcessPriority aInitialPriority) {
   Endpoint<PVRManagerChild> vrBridge;
   Endpoint<PVideoDecoderManagerChild> videoManager;
   AutoTArray<uint32_t, 3> namespaces;
+  DebugOnly<bool> opened;
 
-  DebugOnly<bool> opened =
+#ifdef MOZ_WIDGET_GONK
+  Endpoint<PSharedBufferManagerChild> bufferManager;
+  opened = gpm->CreateBufferManager(OtherPid(), &bufferManager);
+  MOZ_ASSERT(opened);
+  Unused << SendInitBufferManager(std::move(bufferManager));
+#endif
+  opened =
       gpm->CreateContentBridges(OtherPid(), &compositor, &imageBridge,
                                 &vrBridge, &videoManager, &namespaces);
   MOZ_ASSERT(opened);
@@ -2678,8 +2685,16 @@ void ContentParent::OnCompositorUnexpectedShutdown() {
   Endpoint<PVRManagerChild> vrBridge;
   Endpoint<PVideoDecoderManagerChild> videoManager;
   AutoTArray<uint32_t, 3> namespaces;
+  DebugOnly<bool> opened;
 
-  DebugOnly<bool> opened =
+#ifdef MOZ_WIDGET_GONK
+  Endpoint<PSharedBufferManagerChild> bufferManager;
+  opened = gpm->CreateBufferManager(OtherPid(), &bufferManager);
+  MOZ_ASSERT(opened);
+  Unused << SendReinitBufferManager(std::move(bufferManager));
+#endif
+
+  opened =
       gpm->CreateContentBridges(OtherPid(), &compositor, &imageBridge,
                                 &vrBridge, &videoManager, &namespaces);
   MOZ_ASSERT(opened);

--- a/dom/ipc/PContent.ipdl
+++ b/dom/ipc/PContent.ipdl
@@ -17,6 +17,7 @@ include protocol PFileDescriptorSet;
 include protocol PHal;
 include protocol PHeapSnapshotTempFileHelper;
 include protocol PProcessHangMonitor;
+include protocol PSharedBufferManager;
 include protocol PImageBridge;
 include protocol PIPCBlobInputStream;
 include protocol PLoginReputation;
@@ -404,6 +405,12 @@ child:
     async InitGMPService(Endpoint<PGMPServiceChild> service);
     async InitProcessHangMonitor(Endpoint<PProcessHangMonitorChild> hangMonitor);
     async InitProfiler(Endpoint<PProfilerChild> aEndpoint);
+
+    async InitBufferManager(
+      Endpoint<PSharedBufferManagerChild> bufferManager);
+
+    async ReinitBufferManager(
+      Endpoint<PSharedBufferManagerChild> bufferManager);
 
     // Give the content process its endpoints to the compositor.
     async InitRendering(

--- a/gfx/gl/GLScreenBuffer.cpp
+++ b/gfx/gl/GLScreenBuffer.cpp
@@ -34,6 +34,10 @@
 #  include "SharedSurfaceGLX.h"
 #endif
 
+#ifdef MOZ_WIDGET_GONK
+#  include "SharedSurfaceGralloc.h"
+#endif
+
 namespace mozilla {
 namespace gl {
 
@@ -95,6 +99,10 @@ UniquePtr<SurfaceFactory> GLScreenBuffer::CreateFactory(
     } else {
       factory =
           SurfaceFactory_SurfaceTexture::Create(gl, caps, ipcChannel, flags);
+    }
+#elif defined(MOZ_WIDGET_GONK)
+    if (!gfxPrefs::DisableGralloc()) {
+        factory = MakeUnique<SurfaceFactory_Gralloc>(gl, caps, ipcChannel, flags);
     }
 #else
     if (gl->GetContextType() == GLContextType::EGL) {

--- a/gfx/gl/SharedSurface.h
+++ b/gfx/gl/SharedSurface.h
@@ -50,6 +50,7 @@ namespace gl {
 
 class GLContext;
 class SurfaceFactory;
+class SharedSurface_Gralloc;
 class ShSurfHandle;
 
 class SharedSurface {
@@ -168,6 +169,8 @@ class SharedSurface {
   virtual bool ReadbackBySharedHandle(gfx::DataSourceSurface* out_surface) {
     return false;
   }
+
+  virtual SharedSurface_Gralloc* AsSharedSurface_Gralloc() { return nullptr; }
 };
 
 template <typename T>

--- a/gfx/gl/SharedSurfaceGralloc.h
+++ b/gfx/gl/SharedSurfaceGralloc.h
@@ -8,12 +8,13 @@
 
 #include "mozilla/layers/CompositorTypes.h"
 #include "mozilla/layers/LayersSurfaces.h"
+#include "mozilla/UniquePtr.h"
 #include "SharedSurface.h"
 
 namespace mozilla {
 namespace layers {
+class GrallocTextureData;
 class LayersIPCChannel;
-class TextureClient;
 }
 
 namespace gl {
@@ -41,7 +42,7 @@ protected:
     GLLibraryEGL* const mEGL;
     EGLSync mSync;
     RefPtr<layers::LayersIPCChannel> mAllocator;
-    RefPtr<layers::TextureClient> mTextureClient;
+    UniquePtr<layers::GrallocTextureData> mTextureData;
     const GLuint mProdTex;
 
     SharedSurface_Gralloc(GLContext* prodGL,
@@ -49,7 +50,7 @@ protected:
                           bool hasAlpha,
                           GLLibraryEGL* egl,
                           layers::LayersIPCChannel* allocator,
-                          layers::TextureClient* textureClient,
+                          UniquePtr<layers::GrallocTextureData> textureData,
                           GLuint prodTex);
 
     static bool HasExtensions(GLLibraryEGL* egl, GLContext* gl);
@@ -69,13 +70,15 @@ public:
         return mProdTex;
     }
 
-    layers::TextureClient* GetTextureClient() {
-        return mTextureClient;
-    }
-
     virtual bool ToSurfaceDescriptor(layers::SurfaceDescriptor* const out_descriptor) override;
 
     virtual bool ReadbackBySharedHandle(gfx::DataSourceSurface* out_surface) override;
+
+    virtual SharedSurface_Gralloc* AsSharedSurface_Gralloc() override { return this; }
+
+    layers::GrallocTextureData* GetGrallocTextureData() {
+        return mTextureData.get();
+    }
 };
 
 class SurfaceFactory_Gralloc

--- a/gfx/gl/moz.build
+++ b/gfx/gl/moz.build
@@ -156,5 +156,11 @@ CFLAGS += CONFIG['TK_CFLAGS']
 
 LOCAL_INCLUDES += CONFIG['SKIA_INCLUDES']
 
+if CONFIG['MOZ_WIDGET_TOOLKIT'] == 'gonk':
+    UNIFIED_SOURCES += ['SharedSurfaceGralloc.cpp']
+    EXPORTS += ['SharedSurfaceGralloc.h']
+    LOCAL_INCLUDES += ['/widget/gonk']
+    LOCAL_INCLUDES += ['%' + '%s/%s' % (CONFIG['GONK_PATH'], 'hardware/libhardware/include')]
+
 if CONFIG['CC_TYPE'] in ('clang', 'gcc'):
     CXXFLAGS += ['-Wno-error=shadow']

--- a/gfx/ipc/GPUProcessManager.h
+++ b/gfx/ipc/GPUProcessManager.h
@@ -33,6 +33,7 @@ class CompositorUpdateObserver;
 class PCompositorBridgeChild;
 class PCompositorManagerChild;
 class PImageBridgeChild;
+class PSharedBufferManagerChild;
 class RemoteCompositorSession;
 class InProcessCompositorSession;
 class UiCompositorControllerChild;
@@ -71,6 +72,7 @@ class GPUProcessManager final : public GPUProcessHost::Listener {
   typedef layers::PCompositorBridgeChild PCompositorBridgeChild;
   typedef layers::PCompositorManagerChild PCompositorManagerChild;
   typedef layers::PImageBridgeChild PImageBridgeChild;
+  typedef layers::PSharedBufferManagerChild PSharedBufferManagerChild;
   typedef layers::RemoteCompositorSession RemoteCompositorSession;
   typedef layers::InProcessCompositorSession InProcessCompositorSession;
   typedef layers::UiCompositorControllerChild UiCompositorControllerChild;
@@ -103,6 +105,12 @@ class GPUProcessManager final : public GPUProcessHost::Listener {
       mozilla::ipc::Endpoint<PVRManagerChild>* aOutVRBridge,
       mozilla::ipc::Endpoint<PVideoDecoderManagerChild>* aOutVideoManager,
       nsTArray<uint32_t>* aNamespaces);
+
+#ifdef MOZ_WIDGET_GONK
+  bool CreateBufferManager(
+      base::ProcessId aOtherProcess,
+      mozilla::ipc::Endpoint<PSharedBufferManagerChild>* aOutBufferManager);
+#endif
 
   // Maps the layer tree and process together so that aOwningPID is allowed
   // to access aLayersId across process.
@@ -193,6 +201,12 @@ class GPUProcessManager final : public GPUProcessHost::Listener {
       base::ProcessId aOtherProcess,
       mozilla::ipc::Endpoint<PVideoDecoderManagerChild>* aOutEndPoint);
 
+#ifdef MOZ_WIDGET_GONK
+  bool CreateContentSharedBufferManager(
+      base::ProcessId aOtherProcess,
+      mozilla::ipc::Endpoint<PSharedBufferManagerChild>* aOutEndpoint);
+#endif
+
   // Called from RemoteCompositorSession. We track remote sessions so we can
   // notify their owning widgets that the session must be restarted.
   void RegisterRemoteProcessSession(RemoteCompositorSession* aSession);
@@ -225,6 +239,10 @@ class GPUProcessManager final : public GPUProcessHost::Listener {
 
   void EnsureProtocolsReady();
   void EnsureCompositorManagerChild();
+
+#ifdef MOZ_WIDGET_GONK
+  void EnsureSharedBufferManagerChild();
+#endif
   void EnsureImageBridgeChild();
   void EnsureVRManager();
 

--- a/gfx/layers/Compositor.h
+++ b/gfx/layers/Compositor.h
@@ -26,6 +26,10 @@
 #include <vector>
 #include "mozilla/WidgetUtils.h"
 
+#ifdef MOZ_WIDGET_GONK
+#  include "mozilla/layers/FenceUtils.h"
+#endif
+
 /**
  * Different elements of a web pages are rendered into separate "layers" before
  * they are flattened into the final image that is brought to the screen.
@@ -520,6 +524,12 @@ class Compositor : public TextureSourceProvider {
   void SetInvalid();
   virtual bool IsValid() const override;
   CompositorBridgeParent* GetCompositorBridgeParent() const { return mParent; }
+
+#ifdef MOZ_WIDGET_GONK
+  // TODO FIXME
+  void SetDispAcquireFence(Layer* aLayer, nsIWidget* aWidget) {}
+  FenceHandle GetReleaseFence() { return FenceHandle(); }
+#endif
 
  protected:
   void DrawDiagnosticsInternal(DiagnosticFlags aFlags,

--- a/gfx/layers/GrallocImages.cpp
+++ b/gfx/layers/GrallocImages.cpp
@@ -73,14 +73,13 @@ GrallocImage::SetData(const Data& aData)
     return false;
   }
 
-  ClientIPCAllocator* allocator = ImageBridgeChild::GetSingleton();
+  RefPtr<ImageBridgeChild> allocator = ImageBridgeChild::GetSingleton().get();
   GrallocTextureData* texData = GrallocTextureData::Create(mData.mYSize, HAL_PIXEL_FORMAT_YV12,
                                                            gfx::BackendType::NONE,
                                                            GraphicBuffer::USAGE_SW_READ_OFTEN |
                                                              GraphicBuffer::USAGE_SW_WRITE_OFTEN |
                                                              GraphicBuffer::USAGE_HW_TEXTURE,
-                                                           allocator
-  );
+                                                           ImageBridgeChild::GetSingleton().get());
 
   if (!texData) {
     return false;
@@ -375,6 +374,9 @@ ConvertOmxYUVFormatToRGB565(android::sp<GraphicBuffer>& aBuffer,
     return OK;
   }
 
+  // FIXME
+  return BAD_VALUE;
+#if 0
   android::ColorConverter colorConverter((OMX_COLOR_FORMATTYPE)omxFormat,
                                          OMX_COLOR_Format16bitRGB565);
   if (!colorConverter.isValid()) {
@@ -393,6 +395,7 @@ ConvertOmxYUVFormatToRGB565(android::sp<GraphicBuffer>& aBuffer,
   }
 
   return OK;
+#endif
 }
 
 already_AddRefed<gfx::DataSourceSurface>
@@ -469,7 +472,7 @@ GrallocImage::GetNativeBuffer()
 }
 
 TextureClient*
-GrallocImage::GetTextureClient(CompositableClient* aClient)
+GrallocImage::GetTextureClient(KnowsCompositor* aForwarder)
 {
   return mTextureClient;
 }

--- a/gfx/layers/GrallocImages.h
+++ b/gfx/layers/GrallocImages.h
@@ -93,7 +93,7 @@ public:
 
   virtual bool IsValid() { return !!mTextureClient; }
 
-  virtual TextureClient* GetTextureClient(CompositableClient* aClient) override;
+  virtual TextureClient* GetTextureClient(KnowsCompositor* aForwarder) override;
 
   virtual GrallocImage* AsGrallocImage() override
   {

--- a/gfx/layers/ImageContainer.h
+++ b/gfx/layers/ImageContainer.h
@@ -145,6 +145,7 @@ namespace mozilla {
 
 namespace layers {
 
+class GrallocImage;
 class ImageClient;
 class ImageCompositeNotification;
 class ImageContainer;
@@ -214,6 +215,8 @@ class Image {
   int32_t GetSerial() const { return mSerial; }
 
   virtual already_AddRefed<gfx::SourceSurface> GetAsSourceSurface() = 0;
+
+  virtual GrallocImage* AsGrallocImage() { return nullptr; }
 
   virtual bool IsValid() const { return true; }
 

--- a/gfx/layers/ImageTypes.h
+++ b/gfx/layers/ImageTypes.h
@@ -89,7 +89,14 @@ enum class ImageFormat {
    * An opaque handle that refers to an Image stored in the GPU
    * process.
    */
-  GPU_VIDEO
+  GPU_VIDEO,
+
+  /**
+   * The GRALLOC_PLANAR_YCBCR format creates a GrallocImage, a subtype of
+   * PlanarYCbCrImage. It takes a PlanarYCbCrImage data or the raw gralloc
+   * data and can be used as a texture by Gonk backend directly.
+   */
+  GRALLOC_PLANAR_YCBCR,
 };
 
 enum class StereoMode {

--- a/gfx/layers/LayerRenderState.cpp
+++ b/gfx/layers/LayerRenderState.cpp
@@ -1,0 +1,58 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "LayerRenderState.h"
+
+#ifdef MOZ_WIDGET_GONK
+#include <ui/GraphicBuffer.h>
+#endif
+
+namespace mozilla {
+namespace layers {
+
+LayerRenderState::LayerRenderState()
+  : mFlags(LayerRenderStateFlags::LAYER_RENDER_STATE_DEFAULT)
+  , mHasOwnOffset(false)
+#ifdef MOZ_WIDGET_GONK
+  , mSurface(nullptr)
+  , mOverlayId(INVALID_OVERLAY)
+  , mTexture(nullptr)
+#endif
+{
+}
+
+LayerRenderState::LayerRenderState(const LayerRenderState& aOther)
+  : mFlags(aOther.mFlags)
+  , mHasOwnOffset(aOther.mHasOwnOffset)
+  , mOffset(aOther.mOffset)
+#ifdef MOZ_WIDGET_GONK
+  , mSurface(aOther.mSurface)
+  , mOverlayId(aOther.mOverlayId)
+  , mSize(aOther.mSize)
+  , mTexture(aOther.mTexture)
+#endif
+{
+}
+
+LayerRenderState::~LayerRenderState()
+{
+}
+
+#ifdef MOZ_WIDGET_GONK
+LayerRenderState::LayerRenderState(android::GraphicBuffer* aSurface,
+                                   const gfx::IntSize& aSize,
+                                   LayerRenderStateFlags aFlags,
+                                   TextureHost* aTexture)
+  : mFlags(aFlags)
+  , mHasOwnOffset(false)
+  , mSurface(aSurface)
+  , mOverlayId(INVALID_OVERLAY)
+  , mSize(aSize)
+  , mTexture(aTexture)
+{}
+#endif
+
+} // namespace layers
+} // namespace mozilla

--- a/gfx/layers/LayerRenderState.h
+++ b/gfx/layers/LayerRenderState.h
@@ -1,0 +1,116 @@
+/* -*- Mode: C++; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* vim: set ts=8 sts=2 et sw=2 tw=80: */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef GFX_LAYERRENDERSTATE_H
+#define GFX_LAYERRENDERSTATE_H
+
+#include "Units.h"
+#include "mozilla/gfx/Point.h"   // for IntPoint
+#include "mozilla/Maybe.h"
+
+#ifdef MOZ_WIDGET_GONK
+#  include <utils/RefBase.h>
+#if ANDROID_VERSION >= 21
+#  include <utils/NativeHandle.h>
+#endif
+#endif
+
+namespace android {
+class MOZ_EXPORT GraphicBuffer;
+}  // namespace android
+
+namespace mozilla {
+namespace layers {
+
+class TextureHost;
+
+#define INVALID_OVERLAY -1
+
+// LayerRenderState for Composer2D
+// We currently only support Composer2D using gralloc. If we want to be backed
+// by other surfaces we will need a more generic LayerRenderState.
+enum class LayerRenderStateFlags : int8_t {
+  LAYER_RENDER_STATE_DEFAULT = 0,
+  ORIGIN_BOTTOM_LEFT = 1 << 0,
+  BUFFER_ROTATION = 1 << 1,
+  // Notify Composer2D to swap the RB pixels of gralloc buffer
+  FORMAT_RB_SWAP = 1 << 2,
+  // We record opaqueness here alongside the actual surface we're going to
+  // render. This avoids confusion when a layer might return different kinds
+  // of surfaces over time (e.g. video frames).
+  OPAQUE = 1 << 3
+};
+MOZ_MAKE_ENUM_CLASS_BITWISE_OPERATORS(LayerRenderStateFlags)
+
+// The 'ifdef MOZ_WIDGET_GONK' sadness here is because we don't want to include
+// android::sp unless we have to.
+struct LayerRenderState {
+  // Constructors and destructor are defined in LayersTypes.cpp so we don't
+  // have to pull in a definition for GraphicBuffer.h here. In KK at least,
+  // that results in nasty pollution such as libui's hardware.h #defining
+  // 'version_major' and 'version_minor' which conflict with Theora's codec.c...
+  LayerRenderState();
+  LayerRenderState(const LayerRenderState& aOther);
+  ~LayerRenderState();
+
+#ifdef MOZ_WIDGET_GONK
+  LayerRenderState(android::GraphicBuffer* aSurface,
+                   const gfx::IntSize& aSize,
+                   LayerRenderStateFlags aFlags,
+                   TextureHost* aTexture);
+
+  bool OriginBottomLeft() const
+  { return bool(mFlags & LayerRenderStateFlags::ORIGIN_BOTTOM_LEFT); }
+
+  bool BufferRotated() const
+  { return bool(mFlags & LayerRenderStateFlags::BUFFER_ROTATION); }
+
+  bool FormatRBSwapped() const
+  { return bool(mFlags & LayerRenderStateFlags::FORMAT_RB_SWAP); }
+
+  void SetOverlayId(const int32_t& aId)
+  { mOverlayId = aId; }
+
+  android::GraphicBuffer* GetGrallocBuffer() const
+  { return mSurface.get(); }
+
+#if ANDROID_VERSION >= 21
+  android::NativeHandle* GetSidebandStream() const
+  { return mSidebandStream.get(); }
+#endif
+#endif
+
+  void SetOffset(const nsIntPoint& aOffset)
+  {
+    mOffset = aOffset;
+    mHasOwnOffset = true;
+  }
+
+  // see LayerRenderStateFlags
+  LayerRenderStateFlags mFlags;
+  // true if mOffset is applicable
+  bool mHasOwnOffset;
+  // the location of the layer's origin on mSurface
+  nsIntPoint mOffset;
+  // The 'ifdef MOZ_WIDGET_GONK' sadness here is because we don't want to include
+  // android::sp unless we have to.
+#ifdef MOZ_WIDGET_GONK
+  // surface to render
+  android::sp<android::GraphicBuffer> mSurface;
+  int32_t mOverlayId;
+  // size of mSurface
+  gfx::IntSize mSize;
+  TextureHost* mTexture;
+#if ANDROID_VERSION >= 21
+  android::sp<android::NativeHandle> mSidebandStream;
+#endif
+#endif
+};
+
+}  // namespace layers
+}  // namespace mozilla
+
+#endif /* GFX_LAYERRENDERSTATE_H */

--- a/gfx/layers/basic/GrallocTextureHostBasic.cpp
+++ b/gfx/layers/basic/GrallocTextureHostBasic.cpp
@@ -178,24 +178,19 @@ GrallocTextureHostBasic::ClearTextureSource()
   }
 }
 
-void
-GrallocTextureHostBasic::SetCompositor(Compositor* aCompositor)
-{
-  BasicCompositor* compositor = AssertBasicCompositor(aCompositor);
-  if (!compositor) {
+void GrallocTextureHostBasic::SetTextureSourceProvider(
+    TextureSourceProvider* aProvider) {
+  if (!aProvider->AsCompositor() ||
+      !aProvider->AsCompositor()->AsBasicCompositor()) {
+    mTextureSource = nullptr;
     return;
   }
 
-  mCompositor = compositor;
-  if (mTextureSource) {
-    mTextureSource->SetCompositor(compositor);
-  }
-}
+  mProvider = aProvider;
 
-Compositor*
-GrallocTextureHostBasic::GetCompositor()
-{
-  return mCompositor;
+  if (mTextureSource) {
+    mTextureSource->SetTextureSourceProvider(aProvider);
+  }
 }
 
 gfx::SurfaceFormat

--- a/gfx/layers/basic/GrallocTextureHostBasic.h
+++ b/gfx/layers/basic/GrallocTextureHostBasic.h
@@ -26,9 +26,8 @@ public:
   GrallocTextureHostBasic(TextureFlags aFlags,
                           const SurfaceDescriptorGralloc& aDescriptor);
 
-  virtual void SetCompositor(Compositor* aCompositor) override;
-
-  virtual Compositor* GetCompositor() override;
+  virtual void SetTextureSourceProvider(
+      TextureSourceProvider* aProvider) override;
 
   virtual bool Lock() override;
 

--- a/gfx/layers/client/TextureClient.cpp
+++ b/gfx/layers/client/TextureClient.cpp
@@ -52,6 +52,10 @@
 #  include "mozilla/layers/MacIOSurfaceTextureClientOGL.h"
 #endif
 
+#ifdef MOZ_WIDGET_GONK
+#  include "mozilla/layers/GrallocTextureClient.h"
+#endif
+
 #if 0
 #  define RECYCLE_LOG(...) printf_stderr(__VA_ARGS__)
 #else
@@ -1088,6 +1092,18 @@ already_AddRefed<TextureClient> TextureClient::CreateForDrawing(
 #ifdef MOZ_WIDGET_ANDROID
   if (!data && gfxPrefs::UseSurfaceTextureTextures()) {
     data = AndroidNativeWindowTextureData::Create(aSize, aFormat);
+  }
+#endif
+
+#ifdef MOZ_WIDGET_GONK
+  if (!data) {
+    TextureAllocationFlags allocFlags = aAllocFlags;
+    if (aFormat == SurfaceFormat::B8G8R8X8) {
+      // Skia doesn't support RGBX, so ensure we clear the buffer for the proper
+      // alpha values.
+      allocFlags = TextureAllocationFlags(aAllocFlags | ALLOC_CLEAR_BUFFER);
+    }
+    data = GrallocTextureData::CreateForDrawing(aSize, aFormat, moz2DBackend, aAllocator, allocFlags);
   }
 #endif
 

--- a/gfx/layers/client/TextureClient.h
+++ b/gfx/layers/client/TextureClient.h
@@ -227,6 +227,10 @@ class D3D11TextureData;
 class DXGIYCbCrTextureData;
 #endif
 
+#ifdef MOZ_WIDGET_GONK
+class GrallocTextureData;
+#endif
+
 class TextureData {
  public:
   struct Info {
@@ -302,6 +306,10 @@ class TextureData {
   virtual BufferTextureData* AsBufferTextureData() { return nullptr; }
 
   virtual GPUVideoTextureData* AsGPUVideoTextureData() { return nullptr; }
+
+#ifdef MOZ_WIDGET_GONK
+  virtual GrallocTextureData* AsGrallocTextureData() { return nullptr; }
+#endif
 };
 
 /**

--- a/gfx/layers/client/TextureClientSharedSurface.cpp
+++ b/gfx/layers/client/TextureClientSharedSurface.cpp
@@ -14,6 +14,10 @@
 #include "nsThreadUtils.h"
 #include "SharedSurface.h"
 
+#ifdef MOZ_WIDGET_GONK
+#include "SharedSurfaceGralloc.h"
+#endif
+
 using namespace mozilla::gl;
 
 namespace mozilla {
@@ -39,6 +43,16 @@ void SharedSurfaceTextureData::FillInfo(TextureData::Info& aInfo) const {
 bool SharedSurfaceTextureData::Serialize(SurfaceDescriptor& aOutDescriptor) {
   return mSurf->ToSurfaceDescriptor(&aOutDescriptor);
 }
+
+#ifdef MOZ_WIDGET_GONK
+GrallocTextureData* SharedSurfaceTextureData::AsGrallocTextureData() {
+  auto* surf = mSurf->AsSharedSurface_Gralloc();
+  if (!surf) {
+    return nullptr;
+  }
+  return surf->GetGrallocTextureData();
+}
+#endif
 
 SharedSurfaceTextureClient::SharedSurfaceTextureClient(
     SharedSurfaceTextureData* aData, TextureFlags aFlags,

--- a/gfx/layers/client/TextureClientSharedSurface.h
+++ b/gfx/layers/client/TextureClientSharedSurface.h
@@ -27,6 +27,7 @@ class SurfaceFactory;
 
 namespace layers {
 
+class GrallocTextureData;
 class SharedSurfaceTextureClient;
 
 class SharedSurfaceTextureData : public TextureData {
@@ -49,6 +50,10 @@ class SharedSurfaceTextureData : public TextureData {
   virtual bool Serialize(SurfaceDescriptor& aOutDescriptor) override;
 
   virtual void Deallocate(LayersIPCChannel*) override;
+
+#ifdef MOZ_WIDGET_GONK
+  virtual GrallocTextureData* AsGrallocTextureData() override;
+#endif
 
   gl::SharedSurface* Surf() const { return mSurf.get(); }
 };

--- a/gfx/layers/composite/TextureHost.cpp
+++ b/gfx/layers/composite/TextureHost.cpp
@@ -186,6 +186,7 @@ already_AddRefed<TextureHost> TextureHost::Create(
       break;
 
     case SurfaceDescriptor::TSurfaceDescriptorMacIOSurface:
+    case SurfaceDescriptor::TSurfaceDescriptorGralloc:
       if (aBackend == LayersBackend::LAYERS_OPENGL ||
           aBackend == LayersBackend::LAYERS_WR) {
         result = CreateTextureHostOGL(aDesc, aDeallocator, aBackend, aFlags);

--- a/gfx/layers/composite/TextureHost.h
+++ b/gfx/layers/composite/TextureHost.h
@@ -34,6 +34,11 @@
 #include "mozilla/layers/AtomicRefCountedWithFinalize.h"
 #include "mozilla/gfx/Rect.h"
 
+#ifdef MOZ_WIDGET_GONK
+#  include "mozilla/layers/FenceUtils.h"
+#  include "mozilla/layers/LayerRenderState.h"
+#endif
+
 class MacIOSurface;
 namespace mozilla {
 namespace ipc {
@@ -67,6 +72,10 @@ class PTextureParent;
 class TextureParent;
 class WebRenderTextureHost;
 class WrappingTextureSourceYCbCrBasic;
+
+#ifdef MOZ_WIDGET_GONK
+class GrallocTextureHostOGL;
+#endif
 
 /**
  * A view on a TextureHost where the texture is internally represented as tiles
@@ -623,6 +632,9 @@ class TextureHost : public AtomicRefCountedWithFinalize<TextureHost> {
     return nullptr;
   }
   virtual WebRenderTextureHost* AsWebRenderTextureHost() { return nullptr; }
+#ifdef MOZ_WIDGET_GONK
+  virtual GrallocTextureHostOGL* AsGrallocTextureHostOGL() { return nullptr; }
+#endif
 
   // Create the corresponding RenderTextureHost type of this texture, and
   // register the RenderTextureHost into render thread.
@@ -670,6 +682,21 @@ class TextureHost : public AtomicRefCountedWithFinalize<TextureHost> {
 
   virtual bool SupportsWrNativeTexture() { return false; }
 
+#ifdef MOZ_WIDGET_GONK
+  virtual void WaitAcquireFenceHandleSyncComplete() {};
+
+  /**
+   * Specific to B2G's Composer2D
+   * XXX - more doc here
+   */
+  virtual LayerRenderState GetRenderState()
+  {
+    // By default we return an empty render state, this should be overridden
+    // by the TextureHost implementations that are used on B2G with Composer2D
+    return LayerRenderState();
+  }
+#endif
+
  protected:
   virtual void ReadUnlock();
 
@@ -694,6 +721,11 @@ class TextureHost : public AtomicRefCountedWithFinalize<TextureHost> {
   int mCompositableCount;
   uint64_t mFwdTransactionId;
   bool mReadLocked;
+
+#ifdef MOZ_WIDGET_GONK
+  FenceHandle mReleaseFenceHandle;
+  FenceHandle mAcquireFenceHandle;
+#endif
 
   friend class Compositor;
   friend class TextureParent;

--- a/gfx/layers/ipc/CompositorThread.cpp
+++ b/gfx/layers/ipc/CompositorThread.cpp
@@ -11,6 +11,10 @@
 #include "mozilla/layers/ImageBridgeParent.h"
 #include "mozilla/media/MediaSystemResourceService.h"
 
+#ifdef MOZ_WIDGET_GONK
+#  include "mozilla/layers/SharedBufferManagerParent.h"
+#endif
+
 namespace mozilla {
 
 namespace gfx {

--- a/gfx/layers/ipc/LayersSurfaces.ipdlh
+++ b/gfx/layers/ipc/LayersSurfaces.ipdlh
@@ -4,6 +4,8 @@
 
 using struct gfxPoint from "gfxPoint.h";
 using nsIntRegion from "nsRegion.h";
+using struct mozilla::layers::MagicGrallocBufferHandle from "gfxipc/ShadowLayerUtils.h";
+using struct mozilla::layers::GrallocBufferRef from "gfxipc/ShadowLayerUtils.h";
 using struct mozilla::layers::SurfaceDescriptorX11 from "gfxipc/ShadowLayerUtils.h";
 using mozilla::StereoMode from "ImageTypes.h";
 using mozilla::YUVColorSpace from "ImageTypes.h";
@@ -15,12 +17,14 @@ using mozilla::gfx::IntRect from "mozilla/gfx/Rect.h";
 using mozilla::gfx::IntSize from "mozilla/gfx/Point.h";
 using mozilla::ipc::SharedMemoryBasic::Handle from "mozilla/ipc/SharedMemoryBasic.h";
 using gfxImageFormat from "gfxTypes.h";
+using struct mozilla::layers::GonkNativeHandle from "mozilla/layers/GonkNativeHandleUtils.h";
 
 namespace mozilla {
 namespace layers {
 
 union OverlayHandle {
   int32_t;
+  GonkNativeHandle;
   null_t;
 };
 
@@ -30,6 +34,8 @@ struct OverlaySource {
 };
 
 union MaybeMagicGrallocBufferHandle {
+  MagicGrallocBufferHandle;
+  GrallocBufferRef;
   null_t;
 };
 

--- a/gfx/layers/ipc/ShadowLayerUtils.h
+++ b/gfx/layers/ipc/ShadowLayerUtils.h
@@ -28,6 +28,22 @@ struct SurfaceDescriptorX11 {
 }  // namespace mozilla
 #endif
 
+#if defined(MOZ_WIDGET_GONK)
+#  include "mozilla/layers/ShadowLayerUtilsGralloc.h"
+#else
+namespace mozilla {
+namespace layers {
+struct MagicGrallocBufferHandle {
+  bool operator==(const MagicGrallocBufferHandle&) const { return false; }
+};
+
+struct GrallocBufferRef {
+  bool operator==(const GrallocBufferRef&) const { return false; }
+};
+}  // namespace layers
+}  // namespace mozilla
+#endif
+
 namespace IPC {
 
 #if !defined(MOZ_HAVE_SURFACEDESCRIPTORX11)
@@ -40,6 +56,26 @@ struct ParamTraits<mozilla::layers::SurfaceDescriptorX11> {
   }
 };
 #endif  // !defined(MOZ_HAVE_XSURFACEDESCRIPTORX11)
+
+#if !defined(MOZ_HAVE_SURFACEDESCRIPTORGRALLOC)
+template <>
+struct ParamTraits<mozilla::layers::MagicGrallocBufferHandle> {
+  typedef mozilla::layers::MagicGrallocBufferHandle paramType;
+  static void Write(Message*, const paramType&) {}
+  static bool Read(const Message*, PickleIterator*, paramType*) {
+    return false;
+  }
+};
+
+template <>
+struct ParamTraits<mozilla::layers::GrallocBufferRef> {
+  typedef mozilla::layers::GrallocBufferRef paramType;
+  static void Write(Message*, const paramType&) {}
+  static bool Read(const Message*, PickleIterator*, paramType*) {
+    return false;
+  }
+};
+#endif  // !defined(MOZ_HAVE_XSURFACEDESCRIPTORGRALLOC)
 
 template <>
 struct ParamTraits<mozilla::ScreenRotation>

--- a/gfx/layers/ipc/SharedBufferManagerChild.cpp
+++ b/gfx/layers/ipc/SharedBufferManagerChild.cpp
@@ -7,17 +7,13 @@
 
 #include "base/task.h"                  // for NewRunnableFunction, etc
 #include "base/thread.h"                // for Thread
-#include "base/tracked.h"               // for FROM_HERE
 #include "mozilla/gfx/Logging.h"        // for gfxDebug
 #include "mozilla/layers/SharedBufferManagerChild.h"
 #include "mozilla/layers/SharedBufferManagerParent.h"
 #include "mozilla/StaticPtr.h"          // for StaticRefPtr
 #include "mozilla/ReentrantMonitor.h"   // for ReentrantMonitor, etc
+#include "mtransport/runnable_utils.h"
 #include "nsThreadUtils.h"              // fo NS_IsMainThread
-
-#ifdef MOZ_NUWA_PROCESS
-#include "ipc/Nuwa.h"
-#endif
 
 #ifdef MOZ_WIDGET_GONK
 #define LOG(args...) __android_log_print(ANDROID_LOG_INFO, "SBMChild", ## args)
@@ -29,13 +25,14 @@ namespace layers {
 using namespace mozilla::gfx;
 
 // Singleton
+StaticMutex SharedBufferManagerChild::sSharedBufferManagerSingletonLock;
 SharedBufferManagerChild* SharedBufferManagerChild::sSharedBufferManagerChildSingleton = nullptr;
-SharedBufferManagerParent* SharedBufferManagerChild::sSharedBufferManagerParentSingleton = nullptr;
 base::Thread* SharedBufferManagerChild::sSharedBufferManagerChildThread = nullptr;
 
 SharedBufferManagerChild::SharedBufferManagerChild()
+  : mCanSend(false)
 #ifdef MOZ_HAVE_SURFACEDESCRIPTORGRALLOC
-  : mBufferMutex("BufferMonitor")
+  ,mBufferMutex("BufferMonitor")
 #endif
 {
 }
@@ -44,29 +41,6 @@ static bool
 InSharedBufferManagerChildThread()
 {
   return SharedBufferManagerChild::sSharedBufferManagerChildThread->thread_id() == PlatformThread::CurrentId();
-}
-
-// dispatched function
-static void
-DeleteSharedBufferManagerSync(ReentrantMonitor *aBarrier, bool *aDone)
-{
-  ReentrantMonitorAutoEnter autoMon(*aBarrier);
-
-  MOZ_ASSERT(InSharedBufferManagerChildThread(),
-             "Should be in SharedBufferManagerChild thread.");
-  SharedBufferManagerChild::sSharedBufferManagerChildSingleton = nullptr;
-  SharedBufferManagerChild::sSharedBufferManagerParentSingleton = nullptr;
-  *aDone = true;
-  aBarrier->NotifyAll();
-}
-
-// dispatched function
-static void
-ConnectSharedBufferManager(SharedBufferManagerChild *child, SharedBufferManagerParent *parent)
-{
-  MessageLoop *parentMsgLoop = parent->GetMessageLoop();
-  ipc::MessageChannel *parentChannel = parent->GetIPCChannel();
-  child->Open(parentChannel, parentMsgLoop, mozilla::ipc::ChildSide);
 }
 
 base::Thread*
@@ -88,83 +62,118 @@ SharedBufferManagerChild::IsCreated()
 }
 
 void
-SharedBufferManagerChild::StartUp()
-{
-  NS_ASSERTION(NS_IsMainThread(), "Should be on the main Thread!");
-  SharedBufferManagerChild::StartUpOnThread(new base::Thread("BufferMgrChild"));
-}
-
-static void
-ConnectSharedBufferManagerInChildProcess(mozilla::ipc::Transport* aTransport,
-                                         base::ProcessId aOtherPid)
-{
-  // Bind the IPC channel to the shared buffer manager thread.
-  SharedBufferManagerChild::sSharedBufferManagerChildSingleton->Open(aTransport,
-                                                                     aOtherPid,
-                                                                     XRE_GetIOMessageLoop(),
-                                                                     ipc::ChildSide);
-
-#ifdef MOZ_NUWA_PROCESS
-  if (IsNuwaProcess()) {
-    SharedBufferManagerChild::sSharedBufferManagerChildThread
-      ->message_loop()->PostTask(FROM_HERE,
-                                 NewRunnableFunction(NuwaMarkCurrentThread,
-                                                     (void (*)(void *))nullptr,
-                                                     (void *)nullptr));
-  }
-#endif
-}
-
-PSharedBufferManagerChild*
-SharedBufferManagerChild::StartUpInChildProcess(Transport* aTransport,
-                                                base::ProcessId aOtherPid)
-{
-  NS_ASSERTION(NS_IsMainThread(), "Should be on the main Thread!");
-
-  sSharedBufferManagerChildThread = new base::Thread("BufferMgrChild");
-  if (!sSharedBufferManagerChildThread->Start()) {
-    return nullptr;
-  }
-
-  sSharedBufferManagerChildSingleton = new SharedBufferManagerChild();
-  sSharedBufferManagerChildSingleton->GetMessageLoop()->PostTask(
-    FROM_HERE,
-    NewRunnableFunction(ConnectSharedBufferManagerInChildProcess,
-                        aTransport, aOtherPid));
-
-  return sSharedBufferManagerChildSingleton;
-}
-
-void
 SharedBufferManagerChild::ShutDown()
 {
   NS_ASSERTION(NS_IsMainThread(), "Should be on the main Thread!");
-  if (IsCreated()) {
-    SharedBufferManagerChild::DestroyManager();
+  if (RefPtr<SharedBufferManagerChild> child = GetSingleton()) {
+    child->DestroyManager();
     delete sSharedBufferManagerChildThread;
     sSharedBufferManagerChildThread = nullptr;
   }
 }
 
-bool
-SharedBufferManagerChild::StartUpOnThread(base::Thread* aThread)
-{
-  MOZ_ASSERT(aThread, "SharedBufferManager needs a thread.");
-  if (sSharedBufferManagerChildSingleton != nullptr) {
-    return false;
+void
+SharedBufferManagerChild::InitSameProcess() {
+  NS_ASSERTION(NS_IsMainThread(), "Should be on the main Thread!");
+
+  MOZ_ASSERT(!sSharedBufferManagerChildSingleton);
+  MOZ_ASSERT(!sSharedBufferManagerChildThread);
+
+  sSharedBufferManagerChildThread = new base::Thread("BufferMgrChild");
+  if (!sSharedBufferManagerChildThread->IsRunning()) {
+    sSharedBufferManagerChildThread->Start();
   }
 
-  sSharedBufferManagerChildThread = aThread;
-  if (!aThread->IsRunning()) {
-    aThread->Start();
+  RefPtr<SharedBufferManagerChild> child = new SharedBufferManagerChild();
+  RefPtr<SharedBufferManagerParent> parent = SharedBufferManagerParent::CreateSameProcess();
+
+  RefPtr<Runnable> runnable =
+      WrapRunnable(child, &SharedBufferManagerChild::BindSameProcess, parent);
+  child->GetMessageLoop()->PostTask(runnable.forget());
+
+  // Assign this after so other threads can't post messages before we connect to
+  // IPDL.
+  {
+    StaticMutexAutoLock lock(sSharedBufferManagerSingletonLock);
+    sSharedBufferManagerChildSingleton = child;
   }
-  sSharedBufferManagerChildSingleton = new SharedBufferManagerChild();
-  char thrname[128];
-  base::snprintf(thrname, 128, "BufMgrParent#%d", base::Process::Current().pid());
-  sSharedBufferManagerParentSingleton = new SharedBufferManagerParent(
-    nullptr, base::Process::Current().pid(), new base::Thread(thrname));
-  sSharedBufferManagerChildSingleton->ConnectAsync(sSharedBufferManagerParentSingleton);
+}
+
+void SharedBufferManagerChild::Bind(Endpoint<PSharedBufferManagerChild>&& aEndpoint) {
+  if (!aEndpoint.Bind(this)) {
+    return;
+  }
+
+  // This reference is dropped in DeallocPSharedBufferManagerChild.
+  this->AddRef();
+
+  mCanSend = true;
+}
+
+
+void
+SharedBufferManagerChild::BindSameProcess(RefPtr<SharedBufferManagerParent> aParent) {
+  MessageLoop* parentMsgLoop = aParent->GetMessageLoop();
+  ipc::MessageChannel* parentChannel = aParent->GetIPCChannel();
+  Open(parentChannel, parentMsgLoop, mozilla::ipc::ChildSide);
+
+  // This reference is dropped in DeallocPSharedBufferManagerChild.
+  this->AddRef();
+
+  mCanSend = true;
+}
+
+bool SharedBufferManagerChild::InitForContent(Endpoint<PSharedBufferManagerChild>&& aEndpoint) {
+  MOZ_ASSERT(NS_IsMainThread());
+
+  gfxPlatform::GetPlatform();
+
+  if (!sSharedBufferManagerChildThread) {
+    sSharedBufferManagerChildThread = new base::Thread("SharedBufferManagerChild");
+    bool success = sSharedBufferManagerChildThread->Start();
+    MOZ_RELEASE_ASSERT(success, "Failed to start SharedBufferManagerChild thread!");
+  }
+
+  RefPtr<SharedBufferManagerChild> child = new SharedBufferManagerChild();
+
+  RefPtr<Runnable> runnable = NewRunnableMethod<Endpoint<PSharedBufferManagerChild>&&>(
+      "layers::SharedBufferManagerChild::Bind", child, &SharedBufferManagerChild::Bind,
+      std::move(aEndpoint));
+  child->GetMessageLoop()->PostTask(runnable.forget());
+
+  // Assign this after so other threads can't post messages before we connect to
+  // IPDL.
+  {
+    StaticMutexAutoLock lock(sSharedBufferManagerSingletonLock);
+    sSharedBufferManagerChildSingleton = child;
+  }
+
   return true;
+}
+
+bool SharedBufferManagerChild::ReinitForContent(Endpoint<PSharedBufferManagerChild>&& aEndpoint) {
+  MOZ_ASSERT(NS_IsMainThread());
+
+  // Note that at this point, ActorDestroy may not have been called yet,
+  // meaning mCanSend is still true. In this case we will try to send a
+  // synchronous WillClose message to the parent, and will certainly get a
+  // false result and a MsgDropped processing error. This is okay.
+  ShutDown();
+
+  return InitForContent(std::move(aEndpoint));
+}
+
+// dispatched function
+void
+SharedBufferManagerChild::DoShutdown(SynchronousTask* aTask)
+{
+  AutoCompleteTask complete(aTask);
+
+  MOZ_ASSERT(InSharedBufferManagerChildThread(),
+             "Should be in SharedBufferManagerChild thread.");
+  MarkShutDown();
+  StaticMutexAutoLock lock(sSharedBufferManagerSingletonLock);
+  SharedBufferManagerChild::sSharedBufferManagerChildSingleton = nullptr;
 }
 
 void
@@ -175,20 +184,33 @@ SharedBufferManagerChild::DestroyManager()
   // ...because we are about to dispatch synchronous messages to the
   // BufferManagerChild thread.
 
-  if (!IsCreated()) {
-    return;
+  {
+    SynchronousTask task("SharedBufferManagerChild Shutdown lock");
+
+    RefPtr<Runnable> runnable =
+        WrapRunnable(RefPtr<SharedBufferManagerChild>(this),
+                     &SharedBufferManagerChild::DoShutdown, &task);
+    GetMessageLoop()->PostTask(runnable.forget());
+
+    task.Wait();
   }
+}
 
-  ReentrantMonitor barrier("BufferManagerDestroyTask lock");
-  ReentrantMonitorAutoEnter autoMon(barrier);
+void
+SharedBufferManagerChild::ActorDestroy(ActorDestroyReason aWhy) {
+  MOZ_ASSERT(InSharedBufferManagerChildThread());
+  mCanSend = false;
+}
 
-  bool done = false;
-  sSharedBufferManagerChildSingleton->GetMessageLoop()->PostTask(FROM_HERE,
-    NewRunnableFunction(&DeleteSharedBufferManagerSync, &barrier, &done));
-  while (!done) {
-    barrier.Wait();
-  }
+bool
+SharedBufferManagerChild::CanSend() const {
+  return mCanSend;
+}
 
+void
+SharedBufferManagerChild::MarkShutDown() {
+  MOZ_ASSERT(InSharedBufferManagerChildThread());
+  mCanSend = false;
 }
 
 MessageLoop *
@@ -199,27 +221,17 @@ SharedBufferManagerChild::GetMessageLoop() const
       nullptr;
 }
 
-void
-SharedBufferManagerChild::ConnectAsync(SharedBufferManagerParent* aParent)
-{
-  GetMessageLoop()->PostTask(FROM_HERE, NewRunnableFunction(&ConnectSharedBufferManager,
-                                                            this, aParent));
-}
-
 // dispatched function
 void
 SharedBufferManagerChild::AllocGrallocBufferSync(const GrallocParam& aParam,
-                                                 Monitor* aBarrier,
-                                                 bool* aDone)
+                                                 SynchronousTask* aTask)
 {
-  MonitorAutoLock autoMon(*aBarrier);
+  AutoCompleteTask complete(aTask);
 
   sSharedBufferManagerChildSingleton->AllocGrallocBufferNow(aParam.size,
                                                             aParam.format,
                                                             aParam.usage,
                                                             aParam.buffer);
-  *aDone = true;
-  aBarrier->NotifyAll();
 }
 
 // dispatched function
@@ -245,17 +257,16 @@ SharedBufferManagerChild::AllocGrallocBuffer(const gfx::IntSize& aSize,
     return SharedBufferManagerChild::AllocGrallocBufferNow(aSize, aFormat, aUsage, aBuffer);
   }
 
-  Monitor barrier("AllocSurfaceDescriptorGralloc Lock");
-  MonitorAutoLock autoMon(barrier);
-  bool done = false;
+  {
+    SynchronousTask task("SharedBufferManagerChild AllocGrallocBuffer lock");
 
-  GetMessageLoop()->PostTask(
-    FROM_HERE,
-    NewRunnableFunction(&AllocGrallocBufferSync,
-                        GrallocParam(aSize, aFormat, aUsage, aBuffer), &barrier, &done));
+    RefPtr<Runnable> runnable =
+        WrapRunnable(RefPtr<SharedBufferManagerChild>(this),
+                     &SharedBufferManagerChild::AllocGrallocBufferSync,
+                     GrallocParam(aSize, aFormat, aUsage, aBuffer), &task);
+    GetMessageLoop()->PostTask(runnable.forget());
 
-  while (!done) {
-    barrier.Wait();
+    task.Wait();
   }
   return true;
 }
@@ -286,7 +297,7 @@ SharedBufferManagerChild::AllocGrallocBufferNow(const IntSize& aSize,
   }
   return true;
 #else
-  NS_RUNTIMEABORT("No GrallocBuffer for you");
+  MOZ_CRASH("No GrallocBuffer for you");
   return true;
 #endif
 }
@@ -305,8 +316,11 @@ SharedBufferManagerChild::DeallocGrallocBuffer(const mozilla::layers::MaybeMagic
     return SharedBufferManagerChild::DeallocGrallocBufferNow(aBuffer);
   }
 
-  GetMessageLoop()->PostTask(FROM_HERE, NewRunnableFunction(&DeallocGrallocBufferSync,
-                                                            aBuffer));
+  RefPtr<Runnable> runnable =
+      WrapRunnable(RefPtr<SharedBufferManagerChild>(this),
+                   &SharedBufferManagerChild::DeallocGrallocBufferSync,
+                   aBuffer);
+  GetMessageLoop()->PostTask(runnable.forget());
 }
 
 void
@@ -321,7 +335,7 @@ SharedBufferManagerChild::DeallocGrallocBufferNow(const mozilla::layers::MaybeMa
   }
   SendDropGrallocBuffer(aBuffer);
 #else
-  NS_RUNTIMEABORT("No GrallocBuffer for you");
+  MOZ_CRASH("No GrallocBuffer for you");
 #endif
 }
 

--- a/gfx/layers/ipc/SharedBufferManagerParent.cpp
+++ b/gfx/layers/ipc/SharedBufferManagerParent.cpp
@@ -8,16 +8,14 @@
 #include "base/message_loop.h"          // for MessageLoop
 #include "base/process.h"               // for ProcessId
 #include "base/task.h"                  // for CancelableTask, DeleteTask, etc
-#include "base/tracked.h"               // for FROM_HERE
 #include "base/thread.h"
 #include "mozilla/ipc/MessageChannel.h" // for MessageChannel, etc
 #include "mozilla/ipc/ProtocolUtils.h"
 #include "mozilla/ipc/Transport.h"      // for Transport
 #include "mozilla/UniquePtr.h"          // for UniquePtr
-#include "mozilla/unused.h"
+#include "mozilla/Unused.h"
 #include "nsIMemoryReporter.h"
 #ifdef MOZ_WIDGET_GONK
-#include "mozilla/LinuxUtils.h"
 #include "ui/PixelFormat.h"
 #endif
 #include "nsPrintfCString.h"
@@ -36,6 +34,8 @@ map<base::ProcessId, SharedBufferManagerParent* > SharedBufferManagerParent::sMa
 StaticAutoPtr<Monitor> SharedBufferManagerParent::sManagerMonitor;
 uint64_t SharedBufferManagerParent::sBufferKey(0);
 
+// FIXME
+#if 0
 #ifdef MOZ_WIDGET_GONK
 class GrallocReporter final : public nsIMemoryReporter
 {
@@ -111,24 +111,61 @@ void InitGralloc() {
   RegisterStrongMemoryReporter(new GrallocReporter());
 #endif
 }
+#endif
 
 /**
  * Task that deletes SharedBufferManagerParent on a specified thread.
  */
-class DeleteSharedBufferManagerParentTask : public Task
+class DeleteSharedBufferManagerParentTask : public Runnable
 {
 public:
-    explicit DeleteSharedBufferManagerParentTask(UniquePtr<SharedBufferManagerParent> aSharedBufferManager)
-        : mSharedBufferManager(Move(aSharedBufferManager)) {
+    explicit DeleteSharedBufferManagerParentTask(RefPtr<SharedBufferManagerParent> aSharedBufferManager)
+        : Runnable("DeleteSharedBufferManagerParentTask")
+        , mSharedBufferManager(aSharedBufferManager) {
     }
-    virtual void Run() override {}
+    NS_IMETHOD Run() override { return NS_OK; }
 private:
-    UniquePtr<SharedBufferManagerParent> mSharedBufferManager;
+    RefPtr<SharedBufferManagerParent> mSharedBufferManager;
 };
 
-SharedBufferManagerParent::SharedBufferManagerParent(Transport* aTransport, base::ProcessId aOwner, base::Thread* aThread)
-  : mTransport(aTransport)
-  , mThread(aThread)
+/* static */
+SharedBufferManagerParent* SharedBufferManagerParent::CreateSameProcess() {
+  base::ProcessId pid = base::GetCurrentProcId();
+
+  char thrname[128];
+  base::snprintf(thrname, 128, "BufMgrParent#%d", pid);
+
+  RefPtr<SharedBufferManagerParent> parent =
+      new SharedBufferManagerParent(pid, new base::Thread(thrname));
+  parent->mSelfRef = parent;
+  return parent;
+}
+
+/* static */
+bool SharedBufferManagerParent::CreateForContent(
+    Endpoint<PSharedBufferManagerParent>&& aEndpoint) {
+  base::Thread* thread = nullptr;
+  char thrname[128];
+  base::snprintf(thrname, 128, "BufMgrParent#%d", aEndpoint.OtherPid());
+  thread = new base::Thread(thrname);
+
+  RefPtr<SharedBufferManagerParent> bridge =
+      new SharedBufferManagerParent(aEndpoint.OtherPid(), thread);
+  MOZ_ASSERT(thread->IsRunning());
+  thread->message_loop()->PostTask(NewRunnableMethod<Endpoint<PSharedBufferManagerParent>&&>(
+      "layers::SharedBufferManagerParent::Bind", bridge, &SharedBufferManagerParent::Bind,
+      std::move(aEndpoint)));
+
+  return true;
+}
+
+void SharedBufferManagerParent::Bind(Endpoint<PSharedBufferManagerParent>&& aEndpoint) {
+  if (!aEndpoint.Bind(this)) return;
+  mSelfRef = this;
+}
+
+SharedBufferManagerParent::SharedBufferManagerParent(base::ProcessId aOwner, base::Thread* aThread)
+  : mThread(aThread)
   , mMainMessageLoop(MessageLoop::current())
   , mDestroyed(false)
   , mLock("SharedBufferManagerParent.mLock")
@@ -154,10 +191,6 @@ SharedBufferManagerParent::SharedBufferManagerParent(Transport* aTransport, base
 SharedBufferManagerParent::~SharedBufferManagerParent()
 {
   MonitorAutoLock lock(*sManagerMonitor.get());
-  if (mTransport) {
-    XRE_GetIOMessageLoop()->PostTask(FROM_HERE,
-                                     new DeleteTask<Transport>(mTransport));
-  }
   sManagers.erase(mOwner);
   delete mThread;
 }
@@ -170,35 +203,9 @@ SharedBufferManagerParent::ActorDestroy(ActorDestroyReason aWhy)
 #ifdef MOZ_HAVE_SURFACEDESCRIPTORGRALLOC
   mBuffers.clear();
 #endif
-  DeleteSharedBufferManagerParentTask* task =
-    new DeleteSharedBufferManagerParentTask(UniquePtr<SharedBufferManagerParent>(this));
-  mMainMessageLoop->PostTask(FROM_HERE, task);
-}
-
-static void
-ConnectSharedBufferManagerInParentProcess(SharedBufferManagerParent* aManager,
-                                          Transport* aTransport,
-                                          base::ProcessId aOtherPid)
-{
-  aManager->Open(aTransport, aOtherPid, XRE_GetIOMessageLoop(), ipc::ParentSide);
-}
-
-PSharedBufferManagerParent* SharedBufferManagerParent::Create(Transport* aTransport,
-                                                              ProcessId aOtherPid)
-{
-  base::Thread* thread = nullptr;
-  char thrname[128];
-  base::snprintf(thrname, 128, "BufMgrParent#%d", aOtherPid);
-  thread = new base::Thread(thrname);
-
-  SharedBufferManagerParent* manager = new SharedBufferManagerParent(aTransport, aOtherPid, thread);
-  if (!thread->IsRunning()) {
-    thread->Start();
-  }
-  thread->message_loop()->PostTask(FROM_HERE,
-                                   NewRunnableFunction(ConnectSharedBufferManagerInParentProcess,
-                                                       manager, aTransport, aOtherPid));
-  return manager;
+  RefPtr<Runnable> task = new DeleteSharedBufferManagerParentTask(this);
+  mSelfRef = nullptr;
+  mMainMessageLoop->PostTask(task.forget());
 }
 
 bool SharedBufferManagerParent::RecvAllocateGrallocBuffer(const IntSize& aSize, const uint32_t& aFormat, const uint32_t& aUsage, mozilla::layers::MaybeMagicGrallocBufferHandle* aHandle)
@@ -270,10 +277,9 @@ bool SharedBufferManagerParent::RecvDropGrallocBuffer(const mozilla::layers::May
   return true;
 }
 
-/*static*/
-void SharedBufferManagerParent::DropGrallocBufferSync(SharedBufferManagerParent* mgr, mozilla::layers::SurfaceDescriptor aDesc)
+void SharedBufferManagerParent::DropGrallocBufferSync(mozilla::layers::SurfaceDescriptor aDesc)
 {
-  mgr->DropGrallocBufferImpl(aDesc);
+  DropGrallocBufferImpl(aDesc);
 }
 
 /*static*/
@@ -297,8 +303,9 @@ void SharedBufferManagerParent::DropGrallocBuffer(ProcessId id, mozilla::layers:
   if (PlatformThread::CurrentId() == mgr->mThread->thread_id()) {
     MOZ_CRASH("GFX: SharedBufferManagerParent::DropGrallocBuffer should not be called on SharedBufferManagerParent thread");
   } else {
-    mgr->mThread->message_loop()->PostTask(FROM_HERE,
-                                      NewRunnableFunction(&DropGrallocBufferSync, mgr, aDesc));
+    RefPtr<Runnable> runnable =
+        WrapRunnable(RefPtr<SharedBufferManagerParent>(mgr),
+                     &SharedBufferManagerParent::DropGrallocBufferSync, aDesc);
   }
   return;
 }
@@ -371,24 +378,6 @@ SharedBufferManagerParent::GetGraphicBuffer(GrallocBufferRef aRef)
   return parent->GetGraphicBuffer(aRef.mKey);
 }
 #endif
-
-IToplevelProtocol*
-SharedBufferManagerParent::CloneToplevel(const InfallibleTArray<ProtocolFdMapping>& aFds,
-                                 base::ProcessHandle aPeerProcess,
-                                 mozilla::ipc::ProtocolCloneContext* aCtx)
-{
-  for (unsigned int i = 0; i < aFds.Length(); i++) {
-    if (aFds[i].protocolId() == unsigned(GetProtocolId())) {
-      Transport* transport = OpenDescriptor(aFds[i].fd(),
-                                            Transport::MODE_SERVER);
-      PSharedBufferManagerParent* bufferManager = Create(transport, base::GetProcId(aPeerProcess));
-      bufferManager->CloneManagees(this, aCtx);
-      bufferManager->IToplevelProtocol::SetTransport(transport);
-      return bufferManager;
-    }
-  }
-  return nullptr;
-}
 
 } /* namespace layers */
 } /* namespace mozilla */

--- a/gfx/layers/moz.build
+++ b/gfx/layers/moz.build
@@ -28,6 +28,7 @@ EXPORTS += [
     'FrameMetrics.h',
     'GLImages.h',
     'GPUVideoImage.h',
+    'GrallocImages.h',
     'ImageContainer.h',
     'ImageLayers.h',
     'ImageTypes.h',
@@ -186,6 +187,8 @@ EXPORTS.mozilla.layers += [
     'ipc/CompositorVsyncSchedulerOwner.h',
     'ipc/ContentCompositorBridgeParent.h',
     'ipc/FenceUtils.h',
+    'ipc/GonkNativeHandle.h',
+    'ipc/GonkNativeHandleUtils.h',
     'ipc/ImageBridgeChild.h',
     'ipc/ImageBridgeParent.h',
     'ipc/ISurfaceAllocator.h',
@@ -198,6 +201,8 @@ EXPORTS.mozilla.layers += [
     'ipc/RefCountedShmem.h',
     'ipc/RemoteContentController.h',
     'ipc/ShadowLayers.h',
+    'ipc/SharedBufferManagerChild.h',
+    'ipc/SharedBufferManagerParent.h',
     'ipc/SharedPlanarYCbCrImage.h',
     'ipc/SharedRGBImage.h',
     'ipc/SharedSurfacesChild.h',
@@ -225,6 +230,8 @@ EXPORTS.mozilla.layers += [
     'mlgpu/UtilityMLGPU.h',
     'opengl/CompositingRenderTargetOGL.h',
     'opengl/CompositorOGL.h',
+    'opengl/GrallocTextureClient.h',
+    'opengl/GrallocTextureHost.h',
     'opengl/MacIOSurfaceTextureClientOGL.h',
     'opengl/MacIOSurfaceTextureHostOGL.h',
     'opengl/TextureClientOGL.h',
@@ -311,6 +318,35 @@ if CONFIG['MOZ_WIDGET_TOOLKIT'] == 'android':
     ]
     EXPORTS.mozilla.layers += [
         'apz/src/AndroidDynamicToolbarAnimator.h',
+    ]
+
+# NB: Gralloc is available on other platforms that use the android GL
+# libraries, but only Gonk is able to use it reliably because Gecko
+# has full system permissions there.
+if CONFIG['MOZ_WIDGET_TOOLKIT'] == 'gonk':
+    EXPORTS.mozilla.layers += [
+        'basic/GrallocTextureHostBasic.h',
+        'ipc/ShadowLayerUtilsGralloc.h',
+        'LayerRenderState.h',
+    ]
+    UNIFIED_SOURCES += [
+        'basic/GrallocTextureHostBasic.cpp',
+        'GrallocImages.cpp',
+        'opengl/EGLImageHelpers.cpp',
+        'opengl/GrallocTextureClient.cpp',
+        'opengl/GrallocTextureHost.cpp',
+    ]
+    LOCAL_INCLUDES += ['/widget/gonk']
+    if CONFIG['ANDROID_VERSION'] >= '21':
+        LOCAL_INCLUDES += [
+             '%' + '%s/%s' % (CONFIG['GONK_PATH'], d) for d in [
+                 'system/core/libsync/include'
+             ]
+        ]
+    SOURCES += [
+        'ipc/GonkNativeHandle.cpp',
+        'ipc/GonkNativeHandleUtils.cpp',
+        'ipc/ShadowLayerUtilsGralloc.cpp',
     ]
 
 UNIFIED_SOURCES += [
@@ -440,6 +476,8 @@ UNIFIED_SOURCES += [
     'ipc/RefCountedShmem.cpp',
     'ipc/RemoteContentController.cpp',
     'ipc/ShadowLayers.cpp',
+    'ipc/SharedBufferManagerChild.cpp',
+    'ipc/SharedBufferManagerParent.cpp',
     'ipc/SharedPlanarYCbCrImage.cpp',
     'ipc/SharedRGBImage.cpp',
     'ipc/SharedSurfacesChild.cpp',
@@ -448,6 +486,7 @@ UNIFIED_SOURCES += [
     'ipc/UiCompositorControllerParent.cpp',
     'ipc/VideoBridgeChild.cpp',
     'ipc/VideoBridgeParent.cpp',
+    'LayerRenderState.cpp',
     'Layers.cpp',
     'LayerScope.cpp',
     'LayersHelpers.cpp',
@@ -539,6 +578,7 @@ IPDL_SOURCES += [
     'ipc/PCompositorManager.ipdl',
     'ipc/PImageBridge.ipdl',
     'ipc/PLayerTransaction.ipdl',
+    'ipc/PSharedBufferManager.ipdl',
     'ipc/PTexture.ipdl',
     'ipc/PUiCompositorController.ipdl',
     'ipc/PVideoBridge.ipdl',
@@ -575,6 +615,22 @@ if CONFIG['MOZ_DEBUG']:
 
 if CONFIG['MOZ_ENABLE_D3D10_LAYER']:
     DEFINES['MOZ_ENABLE_D3D10_LAYER'] = True
+
+if CONFIG['MOZ_WIDGET_TOOLKIT'] == 'gonk':
+    if CONFIG['ANDROID_VERSION'] >= '17':
+        includes = [
+            'frameworks/av/include/media/stagefright',
+            'frameworks/native/include/media/openmax',
+        ]
+    else:
+        includes = [
+            'frameworks/base/include/media/stagefright',
+            'frameworks/base/include/media/stagefright/openmax',
+        ]
+
+    LOCAL_INCLUDES += [
+        '%' + '%s/%s' % (CONFIG['GONK_PATH'], d) for d in includes
+    ]
 
 if CONFIG['ENABLE_TESTS']:
     DIRS += ['apz/test/gtest']

--- a/gfx/layers/opengl/GrallocTextureClient.cpp
+++ b/gfx/layers/opengl/GrallocTextureClient.cpp
@@ -5,8 +5,9 @@
 
 #ifdef MOZ_WIDGET_GONK
 
+#include "libyuv.h"
 #include "mozilla/gfx/2D.h"
-#include "mozilla/layers/AsyncTransactionTracker.h" // for AsyncTransactionTracker
+//#include "mozilla/layers/AsyncTransactionTracker.h" // for AsyncTransactionTracker
 #include "mozilla/layers/GrallocTextureClient.h"
 #include "mozilla/layers/CompositableForwarder.h"
 #include "mozilla/layers/ISurfaceAllocator.h"
@@ -84,6 +85,7 @@ uint32_t GetAndroidFormat(gfx::SurfaceFormat aFormat)
     return HAL_PIXEL_FORMAT_YV12;
   case gfx::SurfaceFormat::A8:
     NS_WARNING("gralloc does not support SurfaceFormat::A8");
+    return android::PIXEL_FORMAT_UNKNOWN;
   default:
     NS_WARNING("Unsupported surface format");
     return android::PIXEL_FORMAT_UNKNOWN;
@@ -110,10 +112,10 @@ GrallocTextureData::~GrallocTextureData()
 }
 
 void
-GrallocTextureData::Deallocate(ClientIPCAllocator* aAllocator)
+GrallocTextureData::Deallocate(LayersIPCChannel* aAllocator)
 {
   MOZ_ASSERT(aAllocator);
-  if (aAllocator && aAllocator->IPCOpen()) {
+  if (aAllocator) {
     SharedBufferManagerChild::GetSingleton()->DeallocGrallocBuffer(mGrallocHandle);
   }
 
@@ -122,10 +124,10 @@ GrallocTextureData::Deallocate(ClientIPCAllocator* aAllocator)
 }
 
 void
-GrallocTextureData::Forget(ClientIPCAllocator* aAllocator)
+GrallocTextureData::Forget(LayersIPCChannel* aAllocator)
 {
   MOZ_ASSERT(aAllocator);
-  if (aAllocator && aAllocator->IPCOpen()) {
+  if (aAllocator) {
     SharedBufferManagerChild::GetSingleton()->DropGrallocBuffer(mGrallocHandle);
   }
 
@@ -152,6 +154,25 @@ GrallocTextureData::Serialize(SurfaceDescriptor& aOutDescriptor)
 }
 
 void
+GrallocTextureData::WaitForBufferOwnership()
+{
+#if defined(MOZ_WIDGET_GONK) && ANDROID_VERSION >= 17
+   if (mReleaseFenceHandle.IsValid()) {
+     RefPtr<FenceHandle::FdObj> fdObj = mReleaseFenceHandle.GetAndResetFdObj();
+     android::sp<Fence> fence = new Fence(fdObj->GetAndResetFd());
+#if ANDROID_VERSION == 17
+     fence->waitForever(1000, "GrallocTextureClientOGL::Lock");
+     // 1000 is what Android uses. It is a warning timeout in ms.
+     // This timeout was removed in ANDROID_VERSION 18.
+#else
+     fence->waitForever("GrallocTextureClientOGL::Lock");
+#endif
+     mReleaseFenceHandle = FenceHandle();
+   }
+#endif
+}
+
+void
 GrallocTextureData::WaitForFence(FenceHandle* aFence)
 {
 #if defined(MOZ_WIDGET_GONK) && ANDROID_VERSION < 21 && ANDROID_VERSION >= 17
@@ -170,9 +191,11 @@ GrallocTextureData::WaitForFence(FenceHandle* aFence)
 }
 
 bool
-GrallocTextureData::Lock(OpenMode aMode, FenceHandle* aReleaseFence)
+GrallocTextureData::Lock(OpenMode aMode)
 {
   MOZ_ASSERT(!mMappedBuffer);
+  // TODO: Add release fence handling
+  FenceHandle* aReleaseFence = nullptr;
 
   uint32_t usage = 0;
   if (aMode & OpenMode::OPEN_READ) {
@@ -290,15 +313,16 @@ GrallocTextureData::UpdateFromSurface(gfx::SourceSurface* aSurface)
 GrallocTextureData*
 GrallocTextureData::Create(gfx::IntSize aSize, AndroidFormat aAndroidFormat,
                            gfx::BackendType aMoz2dBackend, uint32_t aUsage,
-                           ClientIPCAllocator* aAllocator)
+                           LayersIPCChannel* aAllocator)
 {
   if (!aAllocator || !aAllocator->IPCOpen()) {
     return nullptr;
   }
-  int32_t maxSize = aAllocator->AsClientAllocator()->GetMaxTextureSize();
-  if (aSize.width > maxSize || aSize.height > maxSize) {
-    return nullptr;
-  }
+  // TODO FIXME
+  //int32_t maxSize = aAllocator->GetMaxTextureSize();
+  //if (aSize.width > maxSize || aSize.height > maxSize) {
+  //  return nullptr;
+  //}
   gfx::SurfaceFormat format;
   switch (aAndroidFormat) {
   case android::PIXEL_FORMAT_RGBA_8888:
@@ -345,7 +369,8 @@ GrallocTextureData::Create(gfx::IntSize aSize, AndroidFormat aAndroidFormat,
 GrallocTextureData*
 GrallocTextureData::CreateForDrawing(gfx::IntSize aSize, gfx::SurfaceFormat aFormat,
                                      gfx::BackendType aMoz2dBackend,
-                                     ClientIPCAllocator* aAllocator)
+                                     LayersIPCChannel* aAllocator,
+                                     TextureAllocationFlags aAllocFlags)
 {
   if (DisableGralloc(aFormat, aSize)) {
     return nullptr;
@@ -374,6 +399,26 @@ GrallocTextureData::CreateForDrawing(gfx::IntSize aSize, gfx::SurfaceFormat aFor
     return nullptr;
   }
 
+  if ((aAllocFlags & ALLOC_CLEAR_BUFFER) ||
+      (aAllocFlags & ALLOC_CLEAR_BUFFER_BLACK)) {
+    if (aFormat == gfx::SurfaceFormat::B8G8R8X8) {
+      uint8_t* buffer;
+      status_t rv = data->mGraphicBuffer->lock(android::GraphicBuffer::USAGE_SW_WRITE_OFTEN,
+                                               reinterpret_cast<void**>(&buffer));
+      if (rv != OK) {
+        return nullptr;
+      }
+
+      uint32_t bufSize = data->mGraphicBuffer->getStride() * aSize.height * 4;
+
+      // Even though BGRX was requested, XRGB_UINT32 is what is meant,
+      // so use 0xFF000000 to put alpha in the right place.
+      libyuv::ARGBRect(buffer, bufSize, 0, 0, bufSize / sizeof(uint32_t), 1,
+                       0xFF000000);
+      data->mGraphicBuffer->unlock();
+    }
+  }
+
   DebugOnly<gfx::SurfaceFormat> grallocFormat =
     SurfaceFormatForPixelFormat(data->mGraphicBuffer->getPixelFormat());
   // mFormat may be different from the format the graphic buffer reports if we
@@ -397,7 +442,7 @@ GrallocTextureData::GetTextureFlags() const
 // static
 GrallocTextureData*
 GrallocTextureData::CreateForYCbCr(gfx::IntSize aYSize, gfx::IntSize aCbCrSize,
-                                   ClientIPCAllocator* aAllocator)
+                                   LayersIPCChannel* aAllocator)
 {
   MOZ_ASSERT(aYSize.width == aCbCrSize.width * 2);
   MOZ_ASSERT(aYSize.height == aCbCrSize.height * 2);
@@ -410,7 +455,7 @@ GrallocTextureData::CreateForYCbCr(gfx::IntSize aYSize, gfx::IntSize aCbCrSize,
 // static
 GrallocTextureData*
 GrallocTextureData::CreateForGLRendering(gfx::IntSize aSize, gfx::SurfaceFormat aFormat,
-                                         ClientIPCAllocator* aAllocator)
+                                         LayersIPCChannel* aAllocator)
 {
   if (aFormat == gfx::SurfaceFormat::YUV) {
     return nullptr;
@@ -421,39 +466,13 @@ GrallocTextureData::CreateForGLRendering(gfx::IntSize aSize, gfx::SurfaceFormat 
                                     gfx::BackendType::NONE, usage, aAllocator);
 }
 
-// static
-already_AddRefed<TextureClient>
-GrallocTextureData::TextureClientFromSharedSurface(gl::SharedSurface* abstractSurf,
-                                                   TextureFlags flags)
-{
-  auto surf = gl::SharedSurface_Gralloc::Cast(abstractSurf);
-
-  RefPtr<TextureClient> ret = surf->GetTextureClient();
-
-  TextureFlags mask = TextureFlags::ORIGIN_BOTTOM_LEFT |
-                      TextureFlags::RB_SWAPPED |
-                      TextureFlags::NON_PREMULTIPLIED;
-  TextureFlags required = flags & mask;
-  TextureFlags present = ret->GetFlags() & mask;
-
-  if (present != required) {
-    printf_stderr("Present flags: 0x%x. Required: 0x%x.\n",
-                  (uint32_t)present,
-                  (uint32_t)required);
-    MOZ_CRASH("Flag requirement mismatch.");
-  }
-  return ret.forget();
-}
-
-TextureData*
-GrallocTextureData::CreateSimilar(ClientIPCAllocator* aAllocator,
-                                  TextureFlags aFlags,
-                                  TextureAllocationFlags aAllocFlags) const
-{
+TextureData* GrallocTextureData::CreateSimilar(
+      LayersIPCChannel* aAllocator, LayersBackend aLayersBackend,
+      TextureFlags aFlags, TextureAllocationFlags aAllocFlags) const {
   if (mFormat == gfx::SurfaceFormat::YUV) {
     return GrallocTextureData::CreateForYCbCr(mSize, mSize*2, aAllocator);
   } else {
-    return GrallocTextureData::CreateForDrawing(mSize, mFormat, mMoz2DBackend, aAllocator);
+    return GrallocTextureData::CreateForDrawing(mSize, mFormat, mMoz2DBackend, aAllocator, aAllocFlags);
   }
 }
 

--- a/gfx/layers/opengl/GrallocTextureHost.h
+++ b/gfx/layers/opengl/GrallocTextureHost.h
@@ -28,9 +28,8 @@ public:
 
   virtual void Unlock() override;
 
-  virtual void SetCompositor(Compositor* aCompositor) override;
-
-  virtual Compositor* GetCompositor() override { return mCompositor; }
+  virtual void SetTextureSourceProvider(
+      TextureSourceProvider* aProvider) override;
 
   virtual void DeallocateSharedData() override;
 
@@ -38,7 +37,7 @@ public:
 
   virtual void DeallocateDeviceData() override;
 
-  virtual gfx::SurfaceFormat GetFormat() const;
+  virtual gfx::SurfaceFormat GetFormat() const override;
 
   virtual gfx::IntSize GetSize() const override { return mCropSize; }
 
@@ -62,7 +61,7 @@ public:
 
   gl::GLContext* GetGLContext() const { return mCompositor ? mCompositor->gl() : nullptr; }
 
-  virtual bool NeedsFenceHandle() override
+  bool NeedsFenceHandle()
   {
 #if defined(MOZ_WIDGET_GONK) && ANDROID_VERSION >= 17
     return true;
@@ -71,7 +70,7 @@ public:
 #endif
   }
 
-  virtual FenceHandle GetCompositorReleaseFence() override;
+  FenceHandle GetCompositorReleaseFence();
 
   virtual GrallocTextureHostOGL* AsGrallocTextureHostOGL() override { return this; }
 

--- a/gfx/layers/opengl/TextureHostOGL.cpp
+++ b/gfx/layers/opengl/TextureHostOGL.cpp
@@ -31,6 +31,10 @@
 #  include "mozilla/webrender/RenderAndroidSurfaceTextureHostOGL.h"
 #endif
 
+#ifdef MOZ_WIDGET_GONK
+#  include "mozilla/layers/GrallocTextureHost.h"
+#endif
+
 using namespace mozilla::gl;
 using namespace mozilla::gfx;
 
@@ -82,6 +86,15 @@ already_AddRefed<TextureHost> CreateTextureHostOGL(
       const SurfaceDescriptorMacIOSurface& desc =
           aDesc.get_SurfaceDescriptorMacIOSurface();
       result = new MacIOSurfaceTextureHostOGL(aFlags, desc);
+      break;
+    }
+#endif
+
+#ifdef MOZ_WIDGET_GONK
+    case SurfaceDescriptor::TSurfaceDescriptorGralloc: {
+      const SurfaceDescriptorGralloc& desc =
+        aDesc.get_SurfaceDescriptorGralloc();
+      result = new GrallocTextureHostOGL(aFlags, desc);
       break;
     }
 #endif

--- a/gfx/layers/wr/WebRenderBridgeParent.h
+++ b/gfx/layers/wr/WebRenderBridgeParent.h
@@ -12,6 +12,7 @@
 
 #include "CompositableHost.h"  // for CompositableHost, ImageCompositeNotificationInfo
 #include "GLContextProvider.h"
+#include "Layers.h"
 #include "mozilla/layers/CompositableTransactionParent.h"
 #include "mozilla/layers/CompositorVsyncSchedulerOwner.h"
 #include "mozilla/layers/PWebRenderBridgeParent.h"

--- a/gfx/thebes/gfxPlatform.cpp
+++ b/gfx/thebes/gfxPlatform.cpp
@@ -140,6 +140,10 @@ static const uint32_t kDefaultGlyphCacheSize = -1;
 #include "mozilla/layers/MemoryReportingMLGPU.h"
 #include "prsystem.h"
 
+#ifdef MOZ_WIDGET_GONK
+#include "mozilla/layers/SharedBufferManagerChild.h"
+#endif
+
 namespace mozilla {
 namespace layers {
 void ShutdownTileCache();
@@ -1276,6 +1280,9 @@ void gfxPlatform::ShutdownLayersIPC() {
     if (gfxPrefs::ChildProcessShutdown()) {
       layers::CompositorManagerChild::Shutdown();
       layers::ImageBridgeChild::ShutDown();
+#ifdef MOZ_WIDGET_GONK
+      layers::SharedBufferManagerChild::ShutDown();
+#endif
     }
 
     if (gfxVars::UseOMTP() && !recordreplay::IsRecordingOrReplaying()) {
@@ -1285,6 +1292,9 @@ void gfxPlatform::ShutdownLayersIPC() {
     gfx::VRManagerChild::ShutDown();
     layers::CompositorManagerChild::Shutdown();
     layers::ImageBridgeChild::ShutDown();
+#ifdef MOZ_WIDGET_GONK
+    layers::SharedBufferManagerChild::ShutDown();
+#endif
 
     // This has to happen after shutting down the child protocols.
     layers::CompositorThreadHolder::Shutdown();
@@ -1544,17 +1554,17 @@ void gfxPlatform::ComputeTileSize() {
       w = h = clamped(int32_t(RoundUpPow2(screenSize.width)) / 4, 256, 1024);
     }
 
-//#ifdef MOZ_WIDGET_GONK
-//    android::sp<android::GraphicBuffer> alloc =
-//          new android::GraphicBuffer(w, h, android::PIXEL_FORMAT_RGBA_8888,
-//                                     android::GraphicBuffer::USAGE_SW_READ_OFTEN |
-//                                     android::GraphicBuffer::USAGE_SW_WRITE_OFTEN |
-//                                     android::GraphicBuffer::USAGE_HW_TEXTURE);
-//
-//    if (alloc.get()) {
-//      w = alloc->getStride(); // We want the tiles to be gralloc stride aligned.
-//    }
-//#endif
+#ifdef MOZ_WIDGET_GONK
+    android::sp<android::GraphicBuffer> alloc =
+          new android::GraphicBuffer(w, h, android::PIXEL_FORMAT_RGBA_8888,
+                                     android::GraphicBuffer::USAGE_SW_READ_OFTEN |
+                                     android::GraphicBuffer::USAGE_SW_WRITE_OFTEN |
+                                     android::GraphicBuffer::USAGE_HW_TEXTURE);
+
+    if (alloc.get()) {
+      w = alloc->getStride(); // We want the tiles to be gralloc stride aligned.
+    }
+#endif
   }
 
   // Don't allow changing the tile size after we've set it.

--- a/gfx/thebes/gfxPrefs.h
+++ b/gfx/thebes/gfxPrefs.h
@@ -670,6 +670,7 @@ class gfxPrefs final {
   DECL_GFX_PREF(Live, "layers.shared-buffer-provider.enabled", PersistentBufferProviderSharedEnabled, bool, false);
   DECL_GFX_PREF(Live, "layers.single-tile.enabled",            LayersSingleTileEnabled, bool, true);
   DECL_GFX_PREF(Live, "layers.force-synchronous-resize",       LayersForceSynchronousResize, bool, true);
+  DECL_GFX_PREF(Once, "layers.gralloc.disable",                DisableGralloc, bool, false);
 
   // We allow for configurable and rectangular tile size to avoid wasting memory on devices whose
   // screen size does not align nicely to the default tile size. Although layers can be any size,


### PR DESCRIPTION
It adds basic support of GrallocTextureData/Host. But android::Fence handling is not added yet. It did not cause the problem on emulator M, since the Fence does not exist on emulator M. Though it might cause a problem on a real device like flickering.

GrallocTextureData/Host seemed to work on emulator M. But b2g on the emulator did not generate a content process, then code path related to a content process did not checked. And on the emulator M, WebGL was not supported, since vertex array object was not supported by GLES, then changes to SharedSurface_Gralloc and GLScreenBuffer was not checked.

Gralloc handlings of videos and camera are not supported yet.

Gralloc usage could be disabled by pref layers.gralloc.disable:true.